### PR TITLE
add kernel-source to image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ function build {
         gptboot=/boot/gptboot
     fi
 
-    qemu-img create final.raw 3G
+    qemu-img create final.raw 8G
     md_dev=$(mdconfig -a -t vnode -f final.raw)
     gpart create -s gpt ${md_dev}
     gpart add -t freebsd-boot -s 1024 ${md_dev}
@@ -49,9 +49,10 @@ function build {
         mount /dev/${md_dev}p4 /mnt
     fi
 
-
     curl -L ${BASE_URL}/base.txz | tar vxf - -C /mnt
     curl -L ${BASE_URL}/kernel.txz | tar vxf - -C /mnt
+    curl -L ${BASE_URL}/src.txz | tar vxf - -C /mnt
+
     curl -L -o /mnt/tmp/cloud-init.tar.gz "https://github.com/${repo}/archive/${ref}.tar.gz"
     echo "
 export ASSUME_ALWAYS_YES=YES


### PR DESCRIPTION
Hi!

Thanks for your work on creating the images at: http://bsd-cloud-image.org/

I just recently started using them to automate the build of the xNVMe project: https://xnvme.io/

However, I caught the snag that the kernel sources aren't available with the images and downloading them inside a qemu-instance takes a very very long time, and we need them to compile a kernel-module and some other system headers as well. So, I took a look at your tool and added that, and dumped the image in a DigitalOcean Space:
https://refenv.fra1.digitaloceanspaces.com/freebsd13-ufs-ksrc.qcow2
It grows to about 1.5GB in size

Using it, works as intended, instantiating a qemu-guest with the image takes < 2min, whereas downloading the kernel-source took > 20min. For reference:
* GOOD < 2min, https://github.com/OpenMPDK/xNVMe/actions/runs/1795784990
* BAD  +20min, https://github.com/OpenMPDK/xNVMe/runs/5066563324?check_suite_focus=true

Which is great, however, what I am really interested in, is whether you would consider adding kernel sources to the images at http://bsd-cloud-image.org/ ? I just thought providing a PR and showing the growth in image size and intended use-case would be the best way to ask you :) Looking forward to hearing back from you.

Best,
Simon