### PR TITLE
Make script more robust 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 - Install FreeBSD 13
-- Install dependencies: `sudo pkg install -y qemu git`
+- Install dependencies: `sudo pkg install -y git bash curl`
 - Clone the git repository
 - Run: `build.sh`
 - Done

--- a/build.sh
+++ b/build.sh
@@ -114,7 +114,8 @@ touch /etc/rc.conf
         echo 'vfs.root.mountfrom="zfs:zroot/ROOT/default"' >> /mnt/boot/loader.conf
         echo 'zfs_enable="YES"' >> /mnt/etc/rc.conf
 
-
+        # make sure the directory exists before creating cloud.cfg
+        mkdir -p /mnt/etc/cloud
         echo 'growpart:
    mode: auto
    devices:

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,14 @@ repo="${2:-canonical/cloud-init}"
 ref="${3:-main}"
 debug=$4
 install_media="${install_media:-http}"
+requisite_pkgs="curl"
+
+pkg info --quiet ${requisite_pkgs}
+if [ $? != 0 ]; then
+    echo "Requisite packages are missing, install following packages:" >&2
+    echo "${requisite_pkgs}" | sed -e 's|^|\t|' -e 's| |\n\t|g' >&2
+    exit 1
+fi
 
 set -eux
 root_fs="${root_fs:-zfs}"  # ufs or zfs


### PR DESCRIPTION
This PR is intended to fix this error.
```
./build.sh: line 115: /mnt/etc/cloud/cloud.cfg: No such file or directory
```

Additionally,  I added a check for requisite packages. Currently `curl` is the only package required during build process. If some package is added in the future, add them to `requisite_pkgs` variable (space separated). Then the output will be:

```
# ./build.sh
Requisite packages are missing, install following packages:
        curl
        foo
        bar
```

Finally, I updated README to match current requirements (qemu is not required anymore).